### PR TITLE
Shape 翻译完成

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,6 @@ php build.php
 ## 翻译中的文件
 * src/color/the-color-system.md (@VCEtwp)
 * src/components/app-bars-bottom.md (@zdhxiong)
-* src/shape/about-shape.md (@PaperFlu)
-* src/shape/shape-as-expression.md (@PaperFlu)
-* src/shape/shape-hierarchy.md (@PaperFlu)
-* src/shape/shape-motion.md (@PaperFlu)
 * src/typography/language-support.md (@PaperFlu)
 * src/typography/the-type-system.md (@PaperFlu)
 * src/typography/understanding-typography.md (@PaperFlu)
@@ -124,3 +120,7 @@ php build.php
 * src/communication/launch-screen.md (@zdhxiong)
 * src/communication/onboarding.md (@zdhxiong)
 * src/communication/writing.md (@zdhxiong)
+* src/shape/about-shape.md (@PaperFlu)
+* src/shape/shape-as-expression.md (@PaperFlu)
+* src/shape/shape-hierarchy.md (@PaperFlu)
+* src/shape/shape-motion.md (@PaperFlu)

--- a/src/shape/about-shape.md
+++ b/src/shape/about-shape.md
@@ -4,7 +4,7 @@
 # 关于形状
 
 [en]: <> (Material surfaces can be displayed in different shapes. Shapes direct attention, identify components, communicate state, and express brand.)
-Material 面可以以不同的形状展现。形状集中注意，辨别组件，表达状态，同样宣传品牌。
+材料面可以显示出不同的形状。而形状可以引导注意、分别组件、传递状态、并且宣传品牌。
 
 <nav>
 
@@ -12,7 +12,7 @@ Material 面可以以不同的形状展现。形状集中注意，辨别组件�
 [en]: <> (Shape and meaning)
 [en]: <> (Components and shape)
 * [形塑材料](#shaping-material)
-* [形状和内涵](#shape-meaning)
+* [形状和含义](#shape-meaning)
 * [组件和形状](#components-shape)
 
 </nav></div><div class="article__body">
@@ -24,17 +24,17 @@ Material 面可以以不同的形状展现。形状集中注意，辨别组件�
 ### 关于形状
 
 [en]: <> (Material surfaces have a rectangular shape by default, with 4dp rounded corners. They have adjustable:)
-Material 面默认是矩形，含 4dp 的圆角。它们有可变的：
+材料面默认是矩形，并有 4dp 的圆角。其拥有可控的：
 
 [en]: <> (Corner angles and curves)
 [en]: <> (Edge angles and curves)
 [en]: <> (The number of corners)
-* 角的角度和曲线
-* 边的倾斜角度和曲线
+* 角的角度及曲线
+* 边的倾斜角度及曲线
 * 角数目
 
 [en]: <> (Shape changes, such as rounded or clipped corners, can be subtle or more significant.)
-形状的改变，如将角圆滑或锐化，可以微妙亦或更为明显。
+改变形状时，例如圆滑或锐化边角，变化程度可以微妙也可明显。
 
 <figure>
 
@@ -43,7 +43,7 @@ Material 面默认是矩形，含 4dp 的圆角。它们有可变的：
 <figcaption>
 
 [en]: <> (The default Material shape can be customized.)
-默认 Material 形状可被自定义。
+材料初始形状可以变化定制。
 
 </figcaption></figure>
 
@@ -54,7 +54,7 @@ Material 面默认是矩形，含 4dp 的圆角。它们有可变的：
 #### 要点
 
 [en]: <> (Because unique shapes stand out, they can direct attention to different parts of a screen.)
-因为独特的形状脱颖而出，他们能将注意力集中于屏幕中的不同部分。
+特殊形状因为比较显眼，所以它们能把用户注意力引导到屏幕中不同的特别部分。
 
 <figure>
 
@@ -63,7 +63,7 @@ Material 面默认是矩形，含 4dp 的圆角。它们有可变的：
 <figcaption>
 
 [en]: <> (This combination of a round floating action button and curved bottom app bar stands out from the rectangular shapes elsewhere on screen.)
-这个圆形浮动动作按钮和弯曲的底部应用栏的组合从屏幕上其他地方的矩形形状中凸显出来。
+这个圆形浮钮和弧形底栏的搭配组合，从屏幕上的其余矩形里凸现。
 
 </figcaption></figure>
 
@@ -71,7 +71,7 @@ Material 面默认是矩形，含 4dp 的圆角。它们有可变的：
 #### 个性
 
 [en]: <> (Shape provides a way for users to recognize components and identify different Material surfaces.)
-形状提供了一种方法，帮助用户识别组件和分辨不同的 Material 面。
+形状提供了一种帮助用户认出组件和分别不同材料面的方法。
 
 <figure>
 
@@ -80,7 +80,7 @@ Material 面默认是矩形，含 4dp 的圆角。它们有可变的：
 <figcaption>
 
 [en]: <> (These entry chips can be identified by their consistent use of shape.)
-这些条目碎片可以由它们各一致的形状使用来识别。
+这些条目碎片可以通过其统一的形状使用来被辨识。
 
 </figcaption></figure>
 
@@ -88,7 +88,7 @@ Material 面默认是矩形，含 4dp 的圆角。它们有可变的：
 #### 状态
 
 [en]: <> (You can communicate an element’s change of state by using a different shape from the rest of the elements or surfaces in that group. When using shape to indicate a state change, use it consistently with that state, in every instance it occurs.)
-您可以通过使用与该组其余元素或面不同的形状来传达元素状态的变更。使用形状来表明状态变更时，对该状态需用得一致，不论发生于哪一例中。
+一个元素的状态变更，您可以通过使用一不同于组中其余元素或面的外形来传达表示。使用形状来表现状态变更时，不论是哪次状态变化，对同样的状态需用一致对应的形状。
 
 <figure>
 
@@ -97,7 +97,7 @@ Material 面默认是矩形，含 4dp 的圆角。它们有可变的：
 <figcaption>
 
 [en]: <> (This card changes shape upon selection to indicate it’s been selected.)
-这张卡片在选择时会改变形状以表现它被选了。
+这张卡片在被选时会变形以表现被选。
 
 </figcaption></figure>
 
@@ -105,7 +105,7 @@ Material 面默认是矩形，含 4dp 的圆角。它们有可变的：
 #### 树品牌
 
 [en]: <> (To express a brand’s visual language throughout an app, use shape in tandem with other customizations \(like color\) in consistent ways. Small adjustments to shape, applied strategically through an app, contribute to the overall impression a brand makes.)
-要通过应用来表现品牌视觉语言，用一致的方式结合其它自定义（如颜色）来一起使用。APP 中对形状细致入微的调整，有战略合适地应用，有助于一个品牌的整体形象。
+要通过 app 来表现品牌视觉语言，使用形状时结合其它定制项（如颜色）并确保对应统一。贯穿一个 app 的对形状细致入微的调整，有战略目标的合适地应用，大有利于整体的品牌形象建设。
 
 <figure>
 
@@ -114,15 +114,15 @@ Material 面默认是矩形，含 4dp 的圆角。它们有可变的：
 <figcaption>
 
 [en]: <> (The consistent use of shape throughout this app helps express its brand.)
-贯穿于此 APP 的对形状统一一致的使用有助于展现品牌。
+贯穿此 app 的对应统一的形状使用有助其展现品牌。
 
 </figcaption></figure>
 
 [en]: <> (Displaying shape)
-### 显示形状
+### 显出形状
 
 [en]: <> (Shape is made visible when surface edges have sufficient contrast against their background. By default, Material Design makes shapes noticeable by using shadows to display surfaces edges. Other methods to show surface edges and shapes can be used in combination with shadows, or on their own, such as color fills and opacity, .)
-当面的边与其背景具有足够的对比度时，形状可见。默认情况下，Material Design 通过使用阴影显示面的边缘来使形状变得明显。其它用于显示面边沿及形状的方法可以与阴影结合使用，也可以单独使用，如颜色填充和透明度，。
+当面的边与其背景具有足够的对比度时，形状可见。默认情况下，Material Design 使用阴影现出面的边缘，来使形状可见。其它的用于显出面边沿及形状的方法使用时可以同时结合阴影，亦也可独当一面，如颜色填充和透明度。
 
 <div class="mdui-row-sm-2"><div class="mdui-col"><figure>
 
@@ -133,7 +133,7 @@ Material 面默认是矩形，含 4dp 的圆角。它们有可变的：
 {do}
 
 [en]: <> (A colored fill on this floating action button contrasts with the content on the surface behind it, making its surface edges and shape noticeable.)
-这个浮动动作按钮填充的彩色对比着其后部的面上的内容，使得它面的边缘和形状明显。
+这个浮钮的颜色填充对比后处平面的内容文本，使它的边缘和形状变得明显。
 
 </figcaption></figure></div><div class="mdui-col"><figure>
 
@@ -144,18 +144,18 @@ Material 面默认是矩形，含 4dp 的圆角。它们有可变的：
 {dont}
 
 [en]: <> (A semi-transparent surface and white color makes it hard to see the edges and shape of this floating action button.)
-半透明表面及白色导致很难看到这个浮动动作按钮的边缘和形状。
+半透明表面配上白颜料，致使难以看见这个浮钮的边缘和形状。
 
 </figcaption></figure></div></div>
 
 [en]: <> (Shape and meaning)
-<h2 id="shape-meaning">形状和内涵</h2>
+<h2 id="shape-meaning">形状和含义</h2>
 
 [en]: <> (Communicating meaning)
-### 展现内涵
+### 表达含义
 
 [en]: <> (Shapes can be used to reflect a specific purpose or meaning. Text or icons can help reinforce that meaning when the shape of a surface alone could be ambiguous.)
-形状可以用来体现一具体目的或意思。文字或图标可以加强表意，要是觉得单一的表面形状显得有些模糊不清的话。
+形状可用于影射某一特定目的或含义。若面单一的形状表意模糊不清，可以用文字或图标加强表达。
 
 <figure>
 
@@ -166,7 +166,7 @@ Material 面默认是矩形，含 4dp 的圆角。它们有可变的：
 {do}
 
 [en]: <> (The menu has an arrow-like corner that points toward the navigation drawer, reinforcing that these components are connected.)
-此菜单有一个类似箭头并指向导航抽屉的角，强调了这些组件是相关联的。
+此选单有一角形似箭头并指向导航抽屉，强调这些组件相关联。
 
 </figcaption></figure><figure>
 
@@ -177,7 +177,7 @@ Material 面默认是矩形，含 4dp 的圆角。它们有可变的：
 {dont}
 
 [en]: <> (Don’t use shapes in ways that create ambiguous meaning. This Cancel button’s label text implies that it will return the user to a previous point in the flow, but the arrow-shaped button points forward, as though it continues the flow’s progress.)
-使用的形状不得模糊表意。这个取消按钮的标签上文字暗示它会帮助用户返回流程中的上一点，但该形似箭头的钮又指向前，好像它会推动流程的进展。
+使用的形状不得模糊含义。这个取消按钮标签文字暗示着会帮助用户返回流程前一点，而其箭头形状却指向右方，似乎它是推动流程进展。
 
 </figcaption></figure>
 
@@ -188,12 +188,12 @@ Material 面默认是矩形，含 4dp 的圆角。它们有可变的：
 ### 形塑组件
 
 [en]: <> (Shape both helps users identify components and affects how usable they are. The degree to which components can change their shape depends on:)
-形状既帮助用户判定组件，又影响着其可用性。组件形状的变化程度取决于：
+形状除了帮助用户辨识组件，还会影响组件的可用性。组件形状的变化范围取决于：
 
 [en]: <> (If a component relies on its shape for identification)
 [en]: <> (If it has ergonomic requirements, such as a minimum touch target size)
-* 该组件是否依赖形状以区分
-* 其是否要求符合人体工程学，例如触摸目标的最小尺寸
+* 组件是否依赖形状来分别
+* 是否有符合人体工程学的要求，例如触摸目标要求的最小尺寸
 
 <figure>
 
@@ -204,7 +204,7 @@ Material 面默认是矩形，含 4dp 的圆角。它们有可变的：
 {dont}
 
 [en]: <> (Don’t use shapes that make components unrecognizable.)
-不要用致使组件面目全非难以分辨的外形。
+不要用使得组件面目全非难以分辨的外形。
 
 </figcaption></figure><figure>
 
@@ -215,7 +215,7 @@ Material 面默认是矩形，含 4dp 的圆角。它们有可变的：
 {dont}
 
 [en]: <> (Don’t use shapes that interfere with a component’s ability to receive user input. This button has a touch target that is too small.)
-不要用会干扰组件获知用户行为的外形。此按钮作为触摸目标太小了。
+不要用影响用户操作的形状。此按钮作为触摸目标太小了。
 
 </figcaption></figure><figure>
 
@@ -226,6 +226,6 @@ Material 面默认是矩形，含 4dp 的圆角。它们有可变的：
 {dont}
 
 [en]: <> (Don’t use shapes that make a component unrecognizable. These buttons look very similar to the chips above them, which makes it difficult to distinguish the two components.)
-不要用致使组件面目全非难以分辨的外形。这些按钮看起来非常像它们上面的条条，使得分辨这两个组件变得困难。
+不要用使得组件面目全非难以分辨的外形。这些按钮看起来非常像它们上面的条条，使得分辨这两种组件变得困难。
 
 </figcaption></figure></div>

--- a/src/shape/about-shape.md
+++ b/src/shape/about-shape.md
@@ -4,37 +4,37 @@
 # 关于形状
 
 [en]: <> (Material surfaces can be displayed in different shapes. Shapes direct attention, identify components, communicate state, and express brand.)
-译文
+Material 面可以以不同的形状展现。形状集中注意，辨别组件，表达状态，同样宣传品牌。
 
 <nav>
 
 [en]: <> (Shaping material)
 [en]: <> (Shape and meaning)
 [en]: <> (Components and shape)
-* [译文](#shaping-material)
-* [译文](#shape-meaning)
-* [译文](#components-shape)
+* [形塑材料](#shaping-material)
+* [形状和内涵](#shape-meaning)
+* [组件和形状](#components-shape)
 
 </nav></div><div class="article__body">
 
 [en]: <> (Shaping material)
-<h2 id="shaping-material">译文</h2>
+<h2 id="shaping-material">形塑材料</h2>
 
 [en]: <> (About shape)
-### 译文
+### 关于形状
 
 [en]: <> (Material surfaces have a rectangular shape by default, with 4dp rounded corners. They have adjustable:)
-译文
+Material 面默认是矩形，含 4dp 的圆角。它们有可变的：
 
 [en]: <> (Corner angles and curves)
 [en]: <> (Edge angles and curves)
 [en]: <> (The number of corners)
-* 译文
-* 译文
-* 译文
+* 角的角度和曲线
+* 边的倾斜角度和曲线
+* 角数目
 
 [en]: <> (Shape changes, such as rounded or clipped corners, can be subtle or more significant.)
-译文
+形状的改变，如将角圆滑或锐化，可以微妙亦或更为明显。
 
 <figure>
 
@@ -43,18 +43,18 @@
 <figcaption>
 
 [en]: <> (The default Material shape can be customized.)
-译文
+默认 Material 形状可被自定义。
 
 </figcaption></figure>
 
 [en]: <> (Usage)
-### 译文
+### 用法
 
 [en]: <> (Emphasis)
-#### 译文
+#### 要点
 
 [en]: <> (Because unique shapes stand out, they can direct attention to different parts of a screen.)
-译文
+因为独特的形状脱颖而出，他们能将注意力集中于屏幕中的不同部分。
 
 <figure>
 
@@ -63,15 +63,15 @@
 <figcaption>
 
 [en]: <> (This combination of a round floating action button and curved bottom app bar stands out from the rectangular shapes elsewhere on screen.)
-译文
+这个圆形浮动动作按钮和弯曲的底部应用栏的组合从屏幕上其他地方的矩形形状中凸显出来。
 
 </figcaption></figure>
 
 [en]: <> (Identity)
-#### 译文
+#### 个性
 
 [en]: <> (Shape provides a way for users to recognize components and identify different Material surfaces.)
-译文
+形状提供了一种方法，帮助用户识别组件和分辨不同的 Material 面。
 
 <figure>
 
@@ -80,15 +80,15 @@
 <figcaption>
 
 [en]: <> (These entry chips can be identified by their consistent use of shape.)
-译文
+这些条目碎片可以由它们各一致的形状使用来识别。
 
 </figcaption></figure>
 
 [en]: <> (State)
-#### 译文
+#### 状态
 
 [en]: <> (You can communicate an element’s change of state by using a different shape from the rest of the elements or surfaces in that group. When using shape to indicate a state change, use it consistently with that state, in every instance it occurs.)
-译文
+您可以通过使用与该组其余元素或面不同的形状来传达元素状态的变更。使用形状来表明状态变更时，对该状态需用得一致，不论发生于哪一例中。
 
 <figure>
 
@@ -97,15 +97,15 @@
 <figcaption>
 
 [en]: <> (This card changes shape upon selection to indicate it’s been selected.)
-译文
+这张卡片在选择时会改变形状以表现它被选了。
 
 </figcaption></figure>
 
 [en]: <> (Branding)
-#### 译文
+#### 树品牌
 
 [en]: <> (To express a brand’s visual language throughout an app, use shape in tandem with other customizations \(like color\) in consistent ways. Small adjustments to shape, applied strategically through an app, contribute to the overall impression a brand makes.)
-译文
+要通过应用来表现品牌视觉语言，用一致的方式结合其它自定义（如颜色）来一起使用。APP 中对形状细致入微的调整，有战略合适地应用，有助于一个品牌的整体形象。
 
 <figure>
 
@@ -114,15 +114,15 @@
 <figcaption>
 
 [en]: <> (The consistent use of shape throughout this app helps express its brand.)
-译文
+贯穿于此 APP 的对形状统一一致的使用有助于展现品牌。
 
 </figcaption></figure>
 
 [en]: <> (Displaying shape)
-### 译文
+### 显示形状
 
 [en]: <> (Shape is made visible when surface edges have sufficient contrast against their background. By default, Material Design makes shapes noticeable by using shadows to display surfaces edges. Other methods to show surface edges and shapes can be used in combination with shadows, or on their own, such as color fills and opacity, .)
-译文
+当面的边与其背景具有足够的对比度时，形状可见。默认情况下，Material Design 通过使用阴影显示面的边缘来使形状变得明显。其它用于显示面边沿及形状的方法可以与阴影结合使用，也可以单独使用，如颜色填充和透明度，。
 
 <div class="mdui-row-sm-2"><div class="mdui-col"><figure>
 
@@ -133,7 +133,7 @@
 {do}
 
 [en]: <> (A colored fill on this floating action button contrasts with the content on the surface behind it, making its surface edges and shape noticeable.)
-译文
+这个浮动动作按钮填充的彩色对比着其后部的面上的内容，使得它面的边缘和形状明显。
 
 </figcaption></figure></div><div class="mdui-col"><figure>
 
@@ -144,18 +144,18 @@
 {dont}
 
 [en]: <> (A semi-transparent surface and white color makes it hard to see the edges and shape of this floating action button.)
-译文
+半透明表面及白色导致很难看到这个浮动动作按钮的边缘和形状。
 
 </figcaption></figure></div></div>
 
 [en]: <> (Shape and meaning)
-<h2 id="shape-meaning">译文</h2>
+<h2 id="shape-meaning">形状和内涵</h2>
 
 [en]: <> (Communicating meaning)
-### 译文
+### 展现内涵
 
 [en]: <> (Shapes can be used to reflect a specific purpose or meaning. Text or icons can help reinforce that meaning when the shape of a surface alone could be ambiguous.)
-译文
+形状可以用来体现一具体目的或意思。文字或图标可以加强表意，要是觉得单一的表面形状显得有些模糊不清的话。
 
 <figure>
 
@@ -166,7 +166,7 @@
 {do}
 
 [en]: <> (The menu has an arrow-like corner that points toward the navigation drawer, reinforcing that these components are connected.)
-译文
+此菜单有一个类似箭头并指向导航抽屉的角，强调了这些组件是相关联的。
 
 </figcaption></figure><figure>
 
@@ -177,23 +177,23 @@
 {dont}
 
 [en]: <> (Don’t use shapes in ways that create ambiguous meaning. This Cancel button’s label text implies that it will return the user to a previous point in the flow, but the arrow-shaped button points forward, as though it continues the flow’s progress.)
-译文
+使用的形状不得模糊表意。这个取消按钮的标签上文字暗示它会帮助用户返回流程中的上一点，但该形似箭头的钮又指向前，好像它会推动流程的进展。
 
 </figcaption></figure>
 
 [en]: <> (Components and shape)
-<h2 id="components-shape">译文</h2>
+<h2 id="components-shape">组件和形状</h2>
 
 [en]: <> (Shaping components)
-### 译文
+### 形塑组件
 
 [en]: <> (Shape both helps users identify components and affects how usable they are. The degree to which components can change their shape depends on:)
-译文
+形状既帮助用户判定组件，又影响着其可用性。组件形状的变化程度取决于：
 
 [en]: <> (If a component relies on its shape for identification)
 [en]: <> (If it has ergonomic requirements, such as a minimum touch target size)
-* 译文
-* 译文
+* 该组件是否依赖形状以区分
+* 其是否要求符合人体工程学，例如触摸目标的最小尺寸
 
 <figure>
 
@@ -204,7 +204,7 @@
 {dont}
 
 [en]: <> (Don’t use shapes that make components unrecognizable.)
-译文
+不要用致使组件面目全非难以分辨的外形。
 
 </figcaption></figure><figure>
 
@@ -215,7 +215,7 @@
 {dont}
 
 [en]: <> (Don’t use shapes that interfere with a component’s ability to receive user input. This button has a touch target that is too small.)
-译文
+不要用会干扰组件获知用户行为的外形。此按钮作为触摸目标太小了。
 
 </figcaption></figure><figure>
 
@@ -226,6 +226,6 @@
 {dont}
 
 [en]: <> (Don’t use shapes that make a component unrecognizable. These buttons look very similar to the chips above them, which makes it difficult to distinguish the two components.)
-译文
+不要用致使组件面目全非难以分辨的外形。这些按钮看起来非常像它们上面的条条，使得分辨这两个组件变得困难。
 
 </figcaption></figure></div>

--- a/src/shape/shape-as-expression.md
+++ b/src/shape/shape-as-expression.md
@@ -4,44 +4,44 @@
 # 形状表达
 
 [en]: <> (Shape can communicate an element’s state or help express a brand.)
-译文
+形状能传达一个元素的状态或帮助表现品牌。
 
 <nav>
 
 [en]: <> (Communicating state)
 [en]: <> (Expressing brand)
-* [译文](#communicating-state)
-* [译文](#expressing-brand)
+* [传达状态](#communicating-state)
+* [表现品牌](#expressing-brand)
 
 </nav></div><div class="article__body">
 
 [en]: <> (Communicating state)
-<h2 id="communicating-state">译文</h2>
+<h2 id="communicating-state">传达状态</h2>
 
 [en]: <> (Shape and meaning)
-### 译文
+### 形状和内涵
 
 [en]: <> (Shape can communicate many things about an element, including its current state, the result of a user interaction, or other changes in an app. When used in these ways, shape should be used consistently across the same state and interactions, so that a specific shape means the same thing every time it’s encountered.)
-译文
+形状能传递与元素有关的很多信息，包括当前状态、用户交互结果、或应用中的其他改变。如此使用时，同样的状态和交互应确保形状使用得统一，因此每遇特定形状都意味着同一事情。
 
 [en]: <> (Shape and interaction)
-#### 译文
+#### 形状和交互
 
 [en]: <> (To attach meaning to a specific shape, shape changes can be expressed in tandem with a user-initiated action or state change. For example, morph a shape upon selection, or introduce the shape with an icon or other indicator, to reinforce a shape’s meaning.)
-译文
+要为特定形状附上意思，形状改变的展现可以串在一用户发起的动作或状态改变后。举例，在选择时变形，或引入带有图标或其他指示的形状，以强化形状内涵。
 
 [en]: <> (Non-interactive shapes)
-#### 译文
+#### 非交互式形状
 
 [en]: <> (If a shape isn’t interactive, avoid using shapes with sizes large enough to appear interactive. For example, a small triangular shape on a card shouldn’t be large enough to be mistaken for a tap target if it’s not one.)
-译文
+如果一个形状不是交互式的，则避免使用尺寸大到可以展现交互的形状。举例，一个卡片上的小三角形如果不为点按目标则不应大到可被误判。
 
 <figure><video controls loop muted preload="metadata" class="mdui-video-fluid"><source data-src="{assets_path}/shape/shape-as-expression/communicatingstate-do-reply-1b-v2.mp4" src="{assets_path}/shape/shape-as-expression/communicatingstate-do-reply-1b-v2.mp4" type="video/mp4"></video><figcaption>
 
 {do}
 
 [en]: <> (Shape changes should be clearly linked to a user interaction or other obvious cause. This list item’s shape changes upon passing a gesture threshold, eventually giving its left edge a rounded corner.)
-译文
+形状变化应该与用户交互或其它明显原因清晰关联。这个列表项的形状在越过一个手势阈值后发生变化，最终在它的左边缘带来一个圆角。
 
 </figcaption></figure><div class="mdui-row-sm-2"><div class="mdui-col"><figure>
 
@@ -52,7 +52,7 @@
 {dont}
 
 [en]: <> (Don’t communicate state with shapes that are too small to be noticeable.)
-译文
+不要使用小得难以察觉的形状传递状态。
 
 </figcaption></figure></div><div class="mdui-col"><figure>
 
@@ -63,7 +63,7 @@
 {dont}
 
 [en]: <> (Don’t communicate state with a shape large enough to provide a tap target if it’s not interactive.)
-译文
+若不是交互式的，不要使用大到可以作为点按目标的形状来传递状态。
 
 </figcaption></figure></div></div><figure>
 
@@ -74,12 +74,12 @@
 {caution}
 
 [en]: <> (A shape can be used in ways that makes it unclear whether it’s expressing a state or branding. These folded card corners don’t make it clear if the cards are selected, favorited, or simply expressing brand – because cards can express all of these states. To make meaning clearer, either:)
-译文
+可以使用不清楚其是在传递状态还是表现品牌的形状。这些折叠起来的卡片边角未表明这些卡片是选中，喜爱，还是简单地表现着品牌 – 因为卡片能够传达所有这些状态。要使表意明晰，二选一：
 
 [en]: <> (Clearly connect the change of the corner shape with a user action, like selection or favoriting)
 [en]: <> (Remove the folded shape, but keep the corner angle, to reduce the appearance that the folded shape is interactive)
-* 译文
-* 译文
+* 清楚地把角的形状变化和一用户动作关联起来，如选择或喜爱
+* 移去折叠状，但保留角的角度，以减少该折叠形的可交互感
 
 </figcaption></figure><div class="mdui-row-sm-2"><div class="mdui-col"><figure>
 
@@ -90,7 +90,7 @@
 {do}
 
 [en]: <> (Use shape consistently, so that each shape expresses a single meaning. The rounded corner on selected cards helps the shape develop meaning.)
-译文
+统一一致地使用形状，这样每个形状仅表一个意思。选中的卡片上的圆角有助于形状进行表意。
 
 </figcaption></figure></div><div class="mdui-col"><figure>
 
@@ -101,7 +101,7 @@
 {caution}
 
 [en]: <> (The inconsistent shapes on the corners in this card collection make it unclear if each shape represents something different \(such as distinct groupings\) or is simply brand expression.)
-译文
+此卡片集合上边角的不同形状模糊了各形状是否代表不同的意思（例如不同的分组）或仅仅是表现品牌。
 
 </figcaption></figure></div></div>
 

--- a/src/shape/shape-as-expression.md
+++ b/src/shape/shape-as-expression.md
@@ -106,38 +106,38 @@
 </figcaption></figure></div></div>
 
 [en]: <> (Expressing brand)
-<h2 id="expressing-brand">译文</h2>
+<h2 id="expressing-brand">表现品牌</h2>
 
 [en]: <> (Shape and brand expression)
-### 译文
+### 形状和品牌表达
 
 [en]: <> (Branding with shape)
-#### 译文
+#### 形塑品牌
 
 [en]: <> (Use shape in combination with other customizations, like color and typography, to develop your brand’s visual language. Similar, related shapes help unify brand expression across your app. Your app can use a *shape family* – a set of similar shapes such as oval variations of a circle, or the same angled corner at different scales – across its surfaces, components, and elements. The style of shapes in a shape family, such as organic or geometric forms, should match your brand.)
-译文
+结合其它自定义一起调教形状，如颜色和排版，进而开发您的品牌视觉语言。相似的、关联的形状有助于跨应用地统一您的品牌表达。您的应用可以使用一个*形状系列* – 即一组近似的形状，例如多种离心率的圆，或角度相同大小不同的边角 – 它们广泛遍布于其面，组件，和元素。形状系列中形状的风格，如自然或规则型，应与您的品牌相匹配。
 
 [en]: <> (Mixing shapes)
-#### 译文
+#### 调和形状
 
 [en]: <> (When expressing brand with shape, avoid shapes that:)
-译文
+用形状表现品牌时，避开这样的形状：
 
 [en]: <> (Imply interactivity)
 [en]: <> (Inaccurately express state)
 [en]: <> (Interfere with usability)
-* 译文
-* 译文
-* 译文
+* 暗示着可交互的
+* 会误表现状态的
+* 干扰可用性的
 
 [en]: <> (Mixing both different shape styles, and different shapes altogether, can make it difficult to associate particular shapes with a brand.)
-译文
+混用不同的形状风格，和不同的形状于一处，可能导致难以将特定形状与品牌相联系。
 
 [en]: <> (Shape overuse)
-#### 译文
+#### 形状使用过度
 
 [en]: <> (Overuse of a shape for branding purposes can make it less meaningful because that shape becomes common and less noticeable.)
-译文
+过度使用一个形状于品牌化目的可能会让其不是那么有意义因为这个形状已经普遍存在变得不再引目。
 
 <figure>
 
@@ -148,7 +148,7 @@
 {do}
 
 [en]: <> (Consistent use of shape throughout a product contributes to a brand’s visual language. This product’s components use a shape based on its logo \(1, 2\).)
-译文
+产品中各处对形状的如一使用有利于品牌的视觉语言。此产品组件使用的形状基于其徽标（1，2）。
 
 </figcaption></figure><figure>
 
@@ -159,7 +159,7 @@
 {do}
 
 [en]: <> (This product’s components use a geometric shape based on its logo \(1, 2, 3\).)
-译文
+此产品组件使用的规则型形状基于其徽标（1，2，3）。
 
 </figcaption></figure><div class="mdui-row-sm-2"><div class="mdui-col"><figure>
 
@@ -170,7 +170,7 @@
 {do}
 
 [en]: <> (The curve of the corner reflects the color and curved edge of the logo, without affecting usability.)
-译文
+边角曲线反映了徽标的颜色和曲边，且不影响可用性。
 
 </figcaption></figure></div><div class="mdui-col"><figure>
 
@@ -181,7 +181,7 @@
 {dont}
 
 [en]: <> (Don’t reduce the usability of a component when using shape to express brand. The size of this shape interferes with the usability of the list.)
-译文
+勿以牺牲组件可用性的方式表现品牌。该形状的大小影响了此列表的可用性。
 
 </figcaption></figure></div></div><div class="mdui-row-sm-2"><div class="mdui-col"><figure>
 
@@ -192,7 +192,7 @@
 {caution}
 
 [en]: <> (Overuse of a single shape makes that shape common, and thus less noticeable, which reduces its impact on branding.)
-译文
+过度使用单一形状使该形状变得常见，因而不太明显，亦减少了它在品牌化中的影响。
 
 </figcaption></figure></div><div class="mdui-col"><figure>
 
@@ -203,6 +203,6 @@
 {dont}
 
 [en]: <> (Don’t use shapes that don’t reflect a product’s shape family.)
-译文
+别去用那些不体现产品形状系列的形状。
 
 </figcaption></figure></div></div></div>

--- a/src/shape/shape-hierarchy.md
+++ b/src/shape/shape-hierarchy.md
@@ -4,25 +4,25 @@
 # 形状和层次结构
 
 [en]: <> (Shapes can direct attention to important elements and show how surfaces relate to one another.)
-译文
+形状能聚注意焦于重要的元素并展现面与面间的相互关系。
 
 <nav>
 
 [en]: <> (Developing hierarchy)
 [en]: <> (Surface relationships)
-* [译文](#developing-hierarchy)
-* [译文](#surface-relationships)
+* [构建层次结构](#developing-hierarchy)
+* [面与面间关系](#surface-relationships)
 
 </nav></div><div class="article__body">
 
 [en]: <> (Developing hierarchy)
-<h2 id="developing-hierarchy">译文</h2>
+<h2 id="developing-hierarchy">构建层次结构</h2>
 
 [en]: <> (Unique shapes)
-### 译文
+### 独特的形状
 
 [en]: <> (Shapes that are unique differ from the shapes around them, making them stand out. Components with unique shapes stand out from other components, the content that surrounds them, and the UI as a whole. Their shape gives them emphasized importance that helps direct user attention.)
-译文
+形状若特别于周边形状，便会引得注目。有特殊形状的组件会从其余组件，周围文本，以及整个 UI 中脱颖而出。它们的形状强调了它们的重要性，有助于引导用户注意。
 
 <figure>
 
@@ -33,7 +33,7 @@
 {do}
 
 [en]: <> (Make a shape stand out by contrasting it with other shapes. This floating action button’s round shape helps it stand out from other components, which are rectangular.)
-译文
+通过与其它形状形成鲜明对比使形状凸显。这个浮动动作按钮之圆助它脱俗于其它组件，即那些矩形。
 
 </figcaption></figure><figure>
 
@@ -44,36 +44,36 @@
 {dont}
 
 [en]: <> (A shape is less likely to stand out when placed among similar shapes. This floating action button has the same shape as other elements, making it difficult to find.)
-译文
+周围为相似形状时形状不太能凸显。这个浮动动作按钮形同其余元素，致使难以察觉。
 
 </figcaption></figure>
 
 [en]: <> (Surface relationships)
-<h2 id="surface-relationships">译文</h2>
+<h2 id="surface-relationships">面与面间关系</h2>
 
 [en]: <> (Connecting surfaces through shape)
-### 译文
+### 以形接面
 
 [en]: <> (Shape can help users understand how Material surfaces are related to one another.)
-译文
+形状可以帮助用户了解 Material 面之间的相互关系。
 
 [en]: <> (Similar surfaces)
-#### 译文
+#### 相似面
 
 [en]: <> (Similar shapes can indicate that surfaces are peers, such as cards in a collection with matching dimensions and corners.)
-译文
+相似的形状可表明面与面是对等的，就像一个集合中的卡片有着匹配的尺寸和边角。
 
 [en]: <> (Related surfaces)
-#### 译文
+#### 关联面
 
 [en]: <> (Surfaces that are related to one another can be indicated by using shapes that resemble arrows, such that they “point” to other surfaces. For example, an arrow-like corner of a menu can point to a related surface.)
-译文
+表明面与另一面的关系可以通过使用类似箭头的形状，使它们“指向”另一面。举例，菜单中一个类箭头的角可以指向一个关联面。
 
 [en]: <> (Separate surfaces)
-#### 译文
+#### 分离面
 
 [en]: <> (Shapes can emphasize when surfaces are separate from one another. For example, when a unique shape appears at a higher elevation than another surface, it emphasizes that the two surfaces are separate.)
-译文
+形状能强调面面间何时是分离的。举例，当一个独特的形状出现在较另一面更高的位置时，其强调这两面是相分离的。
 
 <div class="mdui-row-sm-2"><div class="mdui-col"><figure>
 
@@ -84,7 +84,7 @@
 {do}
 
 [en]: <> (Curved corners emphasize that the white surface is separate from the purple surface behind it.)
-译文
+圆角强调该白色面与后面的紫色面是相分离的。
 
 </figcaption></figure></div><div class="mdui-col"><figure>
 
@@ -95,7 +95,7 @@
 {do}
 
 [en]: <> (Shape helps emphasize that the surface in the bottom right corner is separate from the surface behind it.)
-译文
+形状协助强调右下角的面是分离于在其后的面的。
 
 </figcaption></figure></div></div><figure>
 
@@ -106,7 +106,7 @@
 {do}
 
 [en]: <> (The similar shape and dimensions of the cards in this collection indicate that they are peers.)
-译文
+这个集合中卡片相似的形状和尺寸表明它们是对等的。
 
 </figcaption></figure><figure>
 
@@ -117,7 +117,7 @@
 {do}
 
 [en]: <> (The unique corner of the menu points to its parent surface.)
-译文
+菜单中独特的这一角指向它的父级面。
 
 </figcaption></figure><figure>
 
@@ -128,6 +128,6 @@
 {dont}
 
 [en]: <> (Don’t use shape to imply that elements are related if they aren’t. The shape of this dialog suggests it is related to the card behind it and to the right.)
-译文
+若并无关，则别用形状暗示元素间有联系。这个对话框的形状表明它与其后卡片及右侧部分相关。
 
 </figcaption></figure></div>

--- a/src/shape/shape-hierarchy.md
+++ b/src/shape/shape-hierarchy.md
@@ -22,7 +22,7 @@
 ### 独特的形状
 
 [en]: <> (Shapes that are unique differ from the shapes around them, making them stand out. Components with unique shapes stand out from other components, the content that surrounds them, and the UI as a whole. Their shape gives them emphasized importance that helps direct user attention.)
-形状若特别于周边形状，便会引得注目。有特殊形状的组件会从其余组件，周围文本，以及整个 UI 中脱颖而出。它们的形状强调了它们的重要性，有助于引导用户注意。
+特别于周边形状的形状，会较为突出。形状特殊的组件会从其余组件、周围文本、以及整个 UI 中凸显出来。其形状重申表现了其之重要，从而有助于集聚用户的注意力。
 
 <figure>
 
@@ -33,7 +33,7 @@
 {do}
 
 [en]: <> (Make a shape stand out by contrasting it with other shapes. This floating action button’s round shape helps it stand out from other components, which are rectangular.)
-通过与其它形状形成鲜明对比使形状凸显。这个浮动动作按钮之圆助它脱俗于其它组件，即那些矩形。
+要使形状凸显，使它与别的形状形成鲜明对比。该浮钮之圆助它脱俗于其它组件，凸显于那些矩形。
 
 </figcaption></figure><figure>
 
@@ -44,36 +44,36 @@
 {dont}
 
 [en]: <> (A shape is less likely to stand out when placed among similar shapes. This floating action button has the same shape as other elements, making it difficult to find.)
-周围为相似形状时形状不太能凸显。这个浮动动作按钮形同其余元素，致使难以察觉。
+形似处不易凸显形状。此浮动按钮形同其它，致使难以察觉。
 
 </figcaption></figure>
 
 [en]: <> (Surface relationships)
-<h2 id="surface-relationships">面与面间关系</h2>
+<h2 id="surface-relationships">二面关系</h2>
 
 [en]: <> (Connecting surfaces through shape)
 ### 以形接面
 
 [en]: <> (Shape can help users understand how Material surfaces are related to one another.)
-形状可以帮助用户了解 Material 面之间的相互关系。
+形状可助用户了解材料面之间的联系。
 
 [en]: <> (Similar surfaces)
 #### 相似面
 
 [en]: <> (Similar shapes can indicate that surfaces are peers, such as cards in a collection with matching dimensions and corners.)
-相似的形状可表明面与面是对等的，就像一个集合中的卡片有着匹配的尺寸和边角。
+相似的形状可表明二面关系对等，例如同一集合中的卡片有着匹配的尺寸和边角。
 
 [en]: <> (Related surfaces)
 #### 关联面
 
 [en]: <> (Surfaces that are related to one another can be indicated by using shapes that resemble arrows, such that they “point” to other surfaces. For example, an arrow-like corner of a menu can point to a related surface.)
-表明面与另一面的关系可以通过使用类似箭头的形状，使它们“指向”另一面。举例，菜单中一个类箭头的角可以指向一个关联面。
+表明二面间关系时可以通过使用像箭头的形状，并使其“指向”另一面。举例，目录中类箭头的一角可以指向一关联面。
 
 [en]: <> (Separate surfaces)
 #### 分离面
 
 [en]: <> (Shapes can emphasize when surfaces are separate from one another. For example, when a unique shape appears at a higher elevation than another surface, it emphasizes that the two surfaces are separate.)
-形状能强调面面间何时是分离的。举例，当一个独特的形状出现在较另一面更高的位置时，其强调这两面是相分离的。
+形状能强调表示二面何时是分离的。举例，当一个特别形状出现在较另一个面的高位时，强调表示这二面相分离。
 
 <div class="mdui-row-sm-2"><div class="mdui-col"><figure>
 
@@ -84,7 +84,7 @@
 {do}
 
 [en]: <> (Curved corners emphasize that the white surface is separate from the purple surface behind it.)
-圆角强调该白色面与后面的紫色面是相分离的。
+圆角强调表示着该白色面与后面的紫色面相分离。
 
 </figcaption></figure></div><div class="mdui-col"><figure>
 
@@ -95,7 +95,7 @@
 {do}
 
 [en]: <> (Shape helps emphasize that the surface in the bottom right corner is separate from the surface behind it.)
-形状协助强调右下角的面是分离于在其后的面的。
+形状协助强调右下角的面是相分离于于其后的面的。
 
 </figcaption></figure></div></div><figure>
 
@@ -106,7 +106,7 @@
 {do}
 
 [en]: <> (The similar shape and dimensions of the cards in this collection indicate that they are peers.)
-这个集合中卡片相似的形状和尺寸表明它们是对等的。
+这个集合中卡片的相似形状和相似尺寸表明它们是对等的。
 
 </figcaption></figure><figure>
 
@@ -117,7 +117,7 @@
 {do}
 
 [en]: <> (The unique corner of the menu points to its parent surface.)
-菜单中独特的这一角指向它的父级面。
+选单中这独特的一角指向它的父级面。
 
 </figcaption></figure><figure>
 
@@ -128,6 +128,6 @@
 {dont}
 
 [en]: <> (Don’t use shape to imply that elements are related if they aren’t. The shape of this dialog suggests it is related to the card behind it and to the right.)
-若并无关，则别用形状暗示元素间有联系。这个对话框的形状表明它与其后卡片及右侧部分相关。
+若并无关，则别用形状暗示元素间有关联。这个对话框的形状表明它关联于后面的卡片以及右侧部分。
 
 </figcaption></figure></div>

--- a/src/shape/shape-motion.md
+++ b/src/shape/shape-motion.md
@@ -4,16 +4,16 @@
 # 形状和动效
 
 [en]: <> (Elements can change shape in response to content changes or user interaction.)
-译文
+元素可以通过变更形状回应内容变更或用户交互。
 
 <nav>
 
 [en]: <> (Usage)
 [en]: <> (Morphing shape)
 [en]: <> (Displaying content)
-* [译文](#usage)
-* [译文](#morphing-shape)
-* [译文](#displaying-content)
+* [用法](#usage)
+* [形状形变](#morphing-shape)
+* [显示内容](#displaying-content)
 
 </nav></div><div class="article__body">
 
@@ -21,134 +21,134 @@
 <h2 id="usage">译文</h2>
 
 [en]: <> (Morphing is the act of changing one shape into another. Shapes can morph in response to changes in state or content, or as a result of user interaction. For example, when rotating a mobile device from portrait to landscape, surfaces can respond by changing size, which can cause shapes to morph.)
-译文
+形变是变一种形状为另一种的行为。形状能够以形变回应状态或内容变更，或作为用户交互结果。举例，将移动设备从纵向旋转至横向时，面可以以尺寸变更作为回应，这就可能导致形状形变。
 
 [en]: <> (Shapes can morph for various reasons, such as to remain consistent with a visual language as surface dimensions change, or to indicate when items are added to a selected set.)
-译文
+形状可能因各种原因产生形变，例如与视觉语言保持一致时随面尺寸变化，或在项目被加进选定集合时进行指明。
 
 [en]: <> (Morphing can cause changes to:)
-译文
+形变可以同时改变：
 
 [en]: <> (Element prominence)
 [en]: <> (Element ergonomics)
 [en]: <> (The meaning of a particular shape)
 [en]: <> (How well a surface expresses a brand’s visual language)
 [en]: <> (Relationships between elements)
-* 译文
-* 译文
-* 译文
-* 译文
-* 译文
+* 元素的明显、重要程度
+* 元素的人体工程程度
+* 特定形状的含义
+* 面表现品牌视觉语言时的表现
+* 元素间关系
 
 <div class="mdui-row-sm-2"><div class="mdui-col"><figure><video controls loop muted preload="metadata" class="mdui-video-fluid"><source data-src="{assets_path}/shape/shape-motion/interactive-do-baseline-1.mp4" src="{assets_path}/shape/shape-motion/interactive-do-baseline-1.mp4" type="video/mp4"></video><figcaption>
 
 {do}
 
 [en]: <> (A shape can morph in response to changes in the UI. This bottom app bar morphs upon the entrance of a floating action button.)
-译文
+形状可以响应 UI 的变化而形变。此底部应用栏在一浮动动作按钮的入口处变形。
 
 </figcaption></figure></div><div class="mdui-col"><figure><video controls loop muted preload="metadata" class="mdui-video-fluid"><source data-src="{assets_path}/shape/shape-motion/interactive-do-baseline-2a.mp4" src="{assets_path}/shape/shape-motion/interactive-do-baseline-2a.mp4" type="video/mp4"></video><figcaption>
 
 {do}
 
 [en]: <> (A surface can reflect state changes by changing its dimensions. The corner of this surface maintains its curve while the edge grows.)
-译文
+面能够通过改变自身尺寸来反应状态变化。这个面的边角在边变长时保留了其曲线。
 
 </figcaption></figure></div></div>
 
 [en]: <> (Morphing shape)
-<h2 id="morphing-shape">译文</h2>
+<h2 id="morphing-shape">形状形变</h2>
 
 [en]: <> (Morphing shape)
-### 译文
+### 形状形变
 
 [en]: <> (As a surface changes size, its shape can maintain its original position or dimensions, it can stretch, or or it can shrink. A shape can also morph between two different shapes.)
-译文
+当面变换型号时，其形状可以保留它原来的位置或尺寸，它或可延展，或可收缩。形状亦可往返于两不同形状中来形变。
 
 [en]: <> (Dimensions)
-### 译文
+### 尺寸
 
 <figure><video controls loop muted preload="metadata" class="mdui-video-fluid"><source data-src="{assets_path}/shape/shape-motion/typesmorphing-do-baseline-1b.mp4" src="{assets_path}/shape/shape-motion/typesmorphing-do-baseline-1b.mp4" type="video/mp4"></video><figcaption>
 
 {do}
 
 [en]: <> (Shape can maintain its original dimensions and position when morphing. This shape \(B\) retains its original dimensions and position relative to one side \(A\) of the surface, while the other side \(C\) stretches.)
-译文
+形状在形变时可以保留它原来的位置和尺寸。这处形状（B）保留了它的原来的尺寸和于一侧（A）的相对位置，而此时另一侧（C）伸长了。
 
 </figcaption></figure><figure><video controls loop muted preload="metadata" class="mdui-video-fluid"><source data-src="{assets_path}/shape/shape-motion/typesmorphing-do-baseline-2b.mp4" src="{assets_path}/shape/shape-motion/typesmorphing-do-baseline-2b.mp4" type="video/mp4"></video><figcaption>
 
 {do}
 
 [en]: <> (A surface may change its dimensions to retain its shape. The height \(A\) of this portion of the surface changes as its width changes in order to maintain its angled slope.)
-译文
+面可能会改变其尺寸以保留原形状。该面上此部分的高（A）如其宽一同发生改变以保留其倾斜斜率。
 
 </figcaption></figure>
 
 [en]: <> (Stretching and shrinking)
-### 译文
+### 延伸和收缩
 
 [en]: <> (A shape can stretch or shrink in response to changes in surface dimensions. Morphing a shape should preserve the proportions of distinctive shapes.)
-译文
+形状能够以延伸或收缩来回应面的尺寸变更。形变形状应要保留形状特殊处的比例。
 
 <figure><video controls loop muted preload="metadata" class="mdui-video-fluid"><source data-src="{assets_path}/shape/shape-motion/typesmorphing-do-baseline-3c.mp4" src="{assets_path}/shape/shape-motion/typesmorphing-do-baseline-3c.mp4" type="video/mp4"></video><figcaption>
 
 {do}
 
 [en]: <> (As this surface stretches, its shape remains recognizable because its distinctive rounded corners keep the same proportions even as portions of the surface change dimensions.)
-译文
+当这个面伸长时，其形状因其独特圆角保留了原比所以即使在面的某些部分改变尺寸时也仍可被辨识。
 
 </figcaption></figure><figure><video controls loop muted preload="metadata" class="mdui-video-fluid"><source data-src="{assets_path}/shape/shape-motion/typesmorphing-dont-baseline-1c.mp4" src="{assets_path}/shape/shape-motion/typesmorphing-dont-baseline-1c.mp4" type="video/mp4"></video><figcaption>
 
 {dont}
 
 [en]: <> (Avoid distorting shapes when stretching or shrinking a surface. This surface’s proportions and rounded corners change as the surface stretches, creating a disconnect between its beginning and end states.)
-译文
+避免在延伸或收缩一个面时扭曲形状。该面的比例和圆角都随面延展而改变，断开了其开始和结束状态间的联系。
 
 </figcaption></figure>
 
 [en]: <> (Resizing shape)
-### 译文
+### 缩放形状
 
 [en]: <> (Maintain the aspect ratio of distinctive shapes when resizing them to avoid shape distortion.)
-译文
+调整大小时保持形状独特部分的纵横比以避免形状扭曲。
 
 <figure><video controls loop muted preload="metadata" class="mdui-video-fluid"><source data-src="{assets_path}/shape/shape-motion/resizing-do-baseline-1d.mp4" src="{assets_path}/shape/shape-motion/resizing-do-baseline-1d.mp4" type="video/mp4"></video><figcaption>
 
 [en]: <> (The corner radius maintains its original aspect ratio when it moves and resizes, supporting a consistent visual language.)
-译文
+圆角半径在位移和变化尺寸时保持原纵横比，维持着统一的视觉语言。
 
 </figcaption></figure>
 
 [en]: <> (Transforming shape)
-### 译文
+### 变换性状
 
 [en]: <> (A shape can transform into a different shape.)
-译文
+形状能变换转化为另一不同形状。
 
 <figure><video controls loop muted preload="metadata" class="mdui-video-fluid"><source data-src="{assets_path}/shape/shape-motion/resizing-caution-baseline-1c.mp4" src="{assets_path}/shape/shape-motion/resizing-caution-baseline-1c.mp4" type="video/mp4"></video><figcaption>
 
 {caution}
 
 [en]: <> (Transforming between similar shapes produces smoother transitions. Transformations between different shapes can display awkward states during a transition.)
-译文
+变换于近似形状之间可产生更为平滑的过渡。相异形状之间的变换在过渡时状态可能会显尴尬。
 
 </figcaption></figure>
 
 [en]: <> (Displaying content)
-<h2 id="displaying-content">译文</h2>
+<h2 id="displaying-content">显示内容</h2>
 
 [en]: <> (Content visibility)
-### 译文
+### 内容可见性
 
 [en]: <> (All content on a surface should be visible while the surface morphs, without clipping content.)
-译文
+面上的所有内容在面形变时均应可见，不应裁切。
 
 <div class="mdui-row-sm-2"><div class="mdui-col"><figure><video controls loop muted preload="metadata" class="mdui-video-fluid"><source data-src="{assets_path}/shape/shape-motion/contentvisibility-do-baseline-1a.mp4" src="{assets_path}/shape/shape-motion/contentvisibility-do-baseline-1a.mp4" type="video/mp4"></video><figcaption>
 
 {do}
 
 [en]: <> (A shaped component should change its dimensions to accommodate content changes, while maintaining that component’s shape.)
-译文
+成形的组件应该改变其尺寸以含纳内容更改，同时保留组件的形状。
 
 </figcaption></figure></div><div class="mdui-col"><figure>
 
@@ -159,58 +159,58 @@
 {dont}
 
 [en]: <> (Don’t separate a surface from its content when morphing. The shape of this top app bar causes these action icons to appear separate from the surface.)
-译文
+形变时不得将面与其内容分离。这个顶部应用栏的形状使这些操作图标显得分离于该面。
 
 </figcaption></figure></div></div>
 
 [en]: <> (Default shape)
-### 译文
+### 原始形状
 
 [en]: <> (By default, Material surfaces are rectangular. They can transform from rectangular shapes into other shapes, and vice versa. For example, a round floating action button can become a rectangular menu, and then return to its original round shape.)
-译文
+默认情况下，Material 面为矩形。它们能变换矩形为其它形状，反之亦然。举例，一个圆形浮动动作按钮能变成一个矩形目录，后再变回它原来的圆形。
 
 [en]: <> (Rectangular shapes maximize the space available for scrollable content and blend in with other rectangular surfaces. As a result, content receives emphasis.)
-译文
+矩形最大化可滚动内容的可用空间并与其它矩面相调和。故而，内容得到特别的重视。
 
 [en]: <> (When using the default rectangular shape, you can add a cue \(such as a collapse or expand icon\) to indicate how to transform the surface.)
-译文
+使用默认的矩形形状时，你可以加入点点暗示（如折叠或展开图标）以表示如何能变换此面。
 
 [en]: <> (Maximize space)
-#### 译文
+#### 最大化空间
 
 [en]: <> (Rectangular shapes maximize space for scrollable content.)
-译文
+矩形最大化可滚动内容的空间。
 
 <figure><video controls loop muted preload="metadata" class="mdui-video-fluid"><source data-src="{assets_path}/shape/shape-motion/closeaffordance-do-baseline-1b.mp4" src="{assets_path}/shape/shape-motion/closeaffordance-do-baseline-1b.mp4" type="video/mp4"></video><figcaption>
 
 {do}
 
 [en]: <> (A round floating action button transitions into a rectangular menu to maximize space for content.)
-译文
+圆形浮动动作按钮转化至矩形选单以最大化内容空间。
 
 </figcaption></figure><figure><video controls loop muted preload="metadata" class="mdui-video-fluid"><source data-src="{assets_path}/shape/shape-motion/closeaffordance-dont-baseline-1b.mp4" src="{assets_path}/shape/shape-motion/closeaffordance-dont-baseline-1b.mp4" type="video/mp4"></video><figcaption>
 
 {dont}
 
 [en]: <> (Choose shapes for expanded surfaces that are optimized for the content they display. This circular menu does not effectively display its content because it maintains the circular shape of the FAB.)
-译文
+选择适于其内容显示的形状来展开面。此圆形选单因为保留浮动动作按钮的圆形致没有有效显示其内容。
 
 </figcaption></figure><figure><video controls loop muted preload="metadata" class="mdui-video-fluid"><source data-src="{assets_path}/shape/shape-motion/returndefaultshape-baseline-1b.mp4" src="{assets_path}/shape/shape-motion/returndefaultshape-baseline-1b.mp4" type="video/mp4"></video><figcaption>
 
 [en]: <> (Space is maximized to display list content when this curved expanding sheet transforms into the default rectangular shape.)
-译文
+空间在这个弧形表格展开变换至默认的矩形形状时最大化地展示列表内容。
 
 </figcaption></figure>
 
 [en]: <> (Focus attention)
-#### 译文
+#### 集中关注
 
 [en]: <> (Rectangular surfaces blend in with other rectangular surfaces, allowing content to receive emphasis.)
-译文
+矩面与其余矩面相调剂，集关注于指定内容。
 
 <figure><video controls loop muted preload="metadata" class="mdui-video-fluid"><source data-src="{assets_path}/shape/shape-motion/returndefaultshape-baseline-2b.mp4" src="{assets_path}/shape/shape-motion/returndefaultshape-baseline-2b.mp4" type="video/mp4"></video><figcaption>
 
 [en]: <> (When the backdrop’s back layer is active, the default shape of the front layer reduces its prominence and focuses user attention on the filter options behind it.)
-译文
+当背景后端被触发激活，前端原形状降低其突出性并把用户的注意带到它后面的过滤选项。
 
 </figcaption></figure></div>


### PR DESCRIPTION
我有一个问题

语句中突然出现的首字母大写 Material（没有 Design）是该翻译成材料呢还是不动？（此版本翻译没有动）
举例，
> Shape can help users understand how **Material surfaces** are related to one another.
形状可以帮助用户了解 Material 面之间的相互关系。

> Shape provides a way for users to recognize components and identify different **Material surfaces**.
形状提供了一种方法，帮助用户识别组件和分辨不同的 Material 面。

> The default **Material shape** can be customized.
默认 Material 形状可被自定义。

要是小写就好办了。