### PR TITLE
fixed build script warnings when dist folder doesn't exist

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -14,7 +14,7 @@ require './vendor/autoload.php';
 define('SRC_PATH', __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'src'); // 源文件存放目录
 define('DIST_PATH', __DIR__ . DIRECTORY_SEPARATOR .'..' . DIRECTORY_SEPARATOR . 'dist'); // 生成的 HTML 文件存放目录
 
-if(realpath(DIST_PATH) === false) {
+if(realpath(DIST_PATH) === false || !is_dir(DIST_PATH)) {
     mkdir(DIST_PATH, 0644, true);
 }
 

--- a/build/build.php
+++ b/build/build.php
@@ -11,8 +11,12 @@ use Komalbarun\DirPy;
 
 require './vendor/autoload.php';
 
-define('SRC_PATH', __DIR__ . '/../src');   // 源文件存放目录
-define('DIST_PATH', __DIR__ . '/../dist'); // 生成的 HTML 文件存放目录
+define('SRC_PATH', __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'src'); // 源文件存放目录
+define('DIST_PATH', __DIR__ . DIRECTORY_SEPARATOR .'..' . DIRECTORY_SEPARATOR . 'dist'); // 生成的 HTML 文件存放目录
+
+if(realpath(DIST_PATH) === false) {
+    mkdir(DIST_PATH, 0644, true);
+}
 
 // 需要全局替换的变量，模板中用 {} 包裹
 $global_params = [


### PR DESCRIPTION
When `dist` folder doesn't exist, dirpy throws two warnings, this PR fixed that by `mkdir` first.